### PR TITLE
RMET-2754 ::: Add Camera Selection

### DIFF
--- a/OSBarcodeLib.xcodeproj/project.pbxproj
+++ b/OSBarcodeLib.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		7507FC1B27FC2AAE003809F6 /* OSBarcodeLib.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7507FC1227FC2AAE003809F6 /* OSBarcodeLib.framework */; };
 		750B35872AFA93B100F90083 /* OSBARCScannerViewConfigurationValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750B35862AFA93B100F90083 /* OSBARCScannerViewConfigurationValues.swift */; };
 		7554D70B2AFA3A0E00D4261C /* ToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7554D70A2AFA3A0E00D4261C /* ToggleButton.swift */; };
+		758E6C162B0238FF00FC16D9 /* OSBARCCameraModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 758E6C152B0238FF00FC16D9 /* OSBARCCameraModel.swift */; };
+		758E6C192B0239E700FC16D9 /* AVCaptureDevice+OSBARCCameraModelMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 758E6C182B0239E700FC16D9 /* AVCaptureDevice+OSBARCCameraModelMappable.swift */; };
 		75A1FC632AFA40D200AA775F /* OSBARCScannerView.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 75A1FC622AFA40D200AA775F /* OSBARCScannerView.xcassets */; };
 		75C20B692AF4FD1900CCB5B1 /* OSBARCTestValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75C20B682AF4FD1900CCB5B1 /* OSBARCTestValues.swift */; };
 		75C20B6B2AF4FE0700CCB5B1 /* OSBARCManagerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75C20B6A2AF4FE0700CCB5B1 /* OSBARCManagerFactoryTests.swift */; };
@@ -48,6 +50,8 @@
 		7507FC1A27FC2AAE003809F6 /* OSBarcodeLibTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OSBarcodeLibTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		750B35862AFA93B100F90083 /* OSBARCScannerViewConfigurationValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSBARCScannerViewConfigurationValues.swift; sourceTree = "<group>"; };
 		7554D70A2AFA3A0E00D4261C /* ToggleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleButton.swift; sourceTree = "<group>"; };
+		758E6C152B0238FF00FC16D9 /* OSBARCCameraModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSBARCCameraModel.swift; sourceTree = "<group>"; };
+		758E6C182B0239E700FC16D9 /* AVCaptureDevice+OSBARCCameraModelMappable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVCaptureDevice+OSBARCCameraModelMappable.swift"; sourceTree = "<group>"; };
 		75A1FC622AFA40D200AA775F /* OSBARCScannerView.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = OSBARCScannerView.xcassets; sourceTree = "<group>"; };
 		75C20B682AF4FD1900CCB5B1 /* OSBARCTestValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSBARCTestValues.swift; sourceTree = "<group>"; };
 		75C20B6A2AF4FE0700CCB5B1 /* OSBARCManagerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSBARCManagerFactoryTests.swift; sourceTree = "<group>"; };
@@ -111,6 +115,7 @@
 		7507FC1427FC2AAE003809F6 /* OSBarcodeLib */ = {
 			isa = PBXGroup;
 			children = (
+				758E6C142B0238F100FC16D9 /* Models */,
 				75E2B20D2AF41B3F00DB689E /* ViewModifiers */,
 				75E2B1D02AF3ADE500DB689E /* Coordinator */,
 				75D20FE02AF16AF1009AD84D /* Manager */,
@@ -131,6 +136,22 @@
 			path = OSBarcodeLibTests;
 			sourceTree = "<group>";
 		};
+		758E6C142B0238F100FC16D9 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				758E6C152B0238FF00FC16D9 /* OSBARCCameraModel.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		758E6C172B0239C100FC16D9 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				758E6C182B0239E700FC16D9 /* AVCaptureDevice+OSBARCCameraModelMappable.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		75D20FE02AF16AF1009AD84D /* Manager */ = {
 			isa = PBXGroup;
 			children = (
@@ -144,6 +165,7 @@
 		75E2B1C32AF3A97400DB689E /* Scanner */ = {
 			isa = PBXGroup;
 			children = (
+				758E6C172B0239C100FC16D9 /* Extensions */,
 				75A1FC622AFA40D200AA775F /* OSBARCScannerView.xcassets */,
 				75E2B1CC2AF3AC5500DB689E /* OSBARCScannerBehaviour.swift */,
 				75E2B1CE2AF3ACE900DB689E /* OSBARCScannerProtocol.swift */,
@@ -330,6 +352,7 @@
 				75E2B1CD2AF3AC5500DB689E /* OSBARCScannerBehaviour.swift in Sources */,
 				75E2B1C72AF3A99A00DB689E /* OSBARCScannerView.swift in Sources */,
 				75E2B1CF2AF3ACE900DB689E /* OSBARCScannerProtocol.swift in Sources */,
+				758E6C192B0239E700FC16D9 /* AVCaptureDevice+OSBARCCameraModelMappable.swift in Sources */,
 				75D20FE92AF17C1C009AD84D /* OSBARCPermissionsProtocol.swift in Sources */,
 				75D20FE52AF17A87009AD84D /* OSBARCCoordinator.swift in Sources */,
 				75D20FE72AF17AFC009AD84D /* OSBARCCoordinatorProtocol.swift in Sources */,
@@ -341,6 +364,7 @@
 				75E2B20F2AF41B5000DB689E /* View+StyleForColour.swift in Sources */,
 				75E2B1D22AF3AE1200DB689E /* OSBARCCoordinatable.swift in Sources */,
 				75E2B1D82AF3C95800DB689E /* OSBARCScannerViewControllerCoordinator.swift in Sources */,
+				758E6C162B0238FF00FC16D9 /* OSBARCCameraModel.swift in Sources */,
 				75D20FDF2AF16AE4009AD84D /* OSBARCManagerProtocol.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/OSBarcodeLib/Manager/OSBARCManagerProtocol.swift
+++ b/OSBarcodeLib/Manager/OSBARCManagerProtocol.swift
@@ -7,6 +7,7 @@ public protocol OSBARCManagerProtocol {
     /// - Parameters:
     ///   - instructionsText: Text to be displayed on the scanner view.
     ///   - buttonText: Text to be displayed for the scan button, if this is configured. `Nil` value means that the button will not be shown.
+    ///   - cameraModel: Camera to use for input gathering.
     /// - Returns: When successful, it returns the text associated with the scanned barcode.
-    func scanBarcode(with instructionsText: String, and buttonText: String?) async throws -> String
+    func scanBarcode(with instructionsText: String, _ buttonText: String?, and cameraModel: OSBARCCameraModel) async throws -> String
 }

--- a/OSBarcodeLib/Models/OSBARCCameraModel.swift
+++ b/OSBarcodeLib/Models/OSBARCCameraModel.swift
@@ -1,0 +1,13 @@
+/// Enumerator with the possible camera to use for video input collection.
+public enum OSBARCCameraModel {
+    case back
+    case front
+}
+
+/// Allows mapping a `OSBARCCameraModel` to whatever class that it implements the protocol.
+protocol OSBARCCameraModelMappable {
+    /// Maps an `OSBARCCameraModel` object into an object of the type of the class it implements
+    /// - Parameter value: Value to map.
+    /// - Returns: Resulting mapped value.
+    static func map(_ value: OSBARCCameraModel) -> Self
+}

--- a/OSBarcodeLib/Scanner/Extensions/AVCaptureDevice+OSBARCCameraModelMappable.swift
+++ b/OSBarcodeLib/Scanner/Extensions/AVCaptureDevice+OSBARCCameraModelMappable.swift
@@ -1,0 +1,5 @@
+import AVFoundation
+
+extension AVCaptureDevice.Position: OSBARCCameraModelMappable {
+    static func map(_ value: OSBARCCameraModel) -> AVCaptureDevice.Position { value == .front ? .front : back }
+}

--- a/OSBarcodeLib/Scanner/OSBARCScannerBehaviour.swift
+++ b/OSBarcodeLib/Scanner/OSBARCScannerBehaviour.swift
@@ -10,7 +10,7 @@ final class OSBARCScannerBehaviour: OSBARCCoordinatable, OSBARCScannerProtocol {
     /// The publisher's cancellable instance collector.
     private var cancellables: Set<AnyCancellable> = []
     
-    func startScanning(with instructionsText: String, and buttonText: String?, _ completion: @escaping (String) -> Void) {
+    func startScanning(with instructionsText: String, _ buttonText: String?, and cameraModel: OSBARCCameraModel, _ completion: @escaping (String) -> Void) {
         $scanResult
             .dropFirst()    // drops the first value - the empty string
             .first()        // only publishes the first barcode value found
@@ -30,7 +30,8 @@ final class OSBARCScannerBehaviour: OSBARCCoordinatable, OSBARCScannerProtocol {
         )
 
         // Get the default camera for capturing videos. This object will allows us to fetch the `hasTorch` method.
-        let captureDevice = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back)
+        let cameraToUse = AVCaptureDevice.Position.map(cameraModel)
+        let captureDevice = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: cameraToUse)
         let cameraHasTorch = captureDevice?.hasTorch ?? false
         
         let buttonText = buttonText ?? ""   // not having the button enabled is translated into having an empty text.

--- a/OSBarcodeLib/Scanner/OSBARCScannerProtocol.swift
+++ b/OSBarcodeLib/Scanner/OSBARCScannerProtocol.swift
@@ -5,5 +5,6 @@ protocol OSBARCScannerProtocol {
     ///   - instructionsText: Text to be displayed on the scanner view.
     ///   - buttonText: Text to be displayed for the scan button, if this is configured. `Nil` value means that the button will not be shown.
     ///   - completion: The value returned or empty string in case the view is closed with no code scanned.
-    func startScanning(with instructionsText: String, and buttonText: String?, _ completion: @escaping (String) -> Void)
+    ///   - cameraModel: Camera to use for input gathering.
+    func startScanning(with instructionsText: String, _ buttonText: String?, and cameraModel: OSBARCCameraModel, _ completion: @escaping (String) -> Void)
 }

--- a/OSBarcodeLibTests/OSBARCManagerTests.swift
+++ b/OSBarcodeLibTests/OSBARCManagerTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 private extension OSBARCManager {
     func scanBarcode() async throws -> String {
-        // `instructionText` and `buttonText` are UI-related so are irrelevant for the unit tests.
-        try await self.scanBarcode(with: "Instruction Text", and: "Scan Button")
+        // `instructionText`, `buttonText` and `cameraModel` are UI-related so are irrelevant for the unit tests.
+        try await self.scanBarcode(with: "Instruction Text", "Scan Button", and: .back)
     }
 }
 

--- a/OSBarcodeLibTests/Stubs/OSBARCScannerStub.swift
+++ b/OSBarcodeLibTests/Stubs/OSBARCScannerStub.swift
@@ -3,7 +3,7 @@
 final class OSBARCScannerStub: OSBARCScannerProtocol {
     var scanCancelled: Bool = false
     
-    func startScanning(with instructionsText: String, and buttonText: String?, _ completion: @escaping (String) -> Void) {
+    func startScanning(with instructionsText: String, _ buttonText: String?, and cameraModel: OSBARCCameraModel, _ completion: @escaping (String) -> Void) {
         completion(self.scanCancelled ? "" : OSBARCScannerStubValues.scannedCode)
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+- Add Camera Selection feature (https://outsystemsrd.atlassian.net/browse/RMET-2754).
 - Add Scan Button feature (https://outsystemsrd.atlassian.net/browse/RMET-2752).
 - Add Scan Instruction text feature (https://outsystemsrd.atlassian.net/browse/RMET-2751).
 - Add Torch Button feature (https://outsystemsrd.atlassian.net/browse/RMET-2749).


### PR DESCRIPTION
## Description
Add the `OSBARCCameraModel` which is an enumerator with all the possible values for the cameras to use: front and back. 

Add an `OSBARCCameraModel` parameter to the `OSBARCManagerProtocol`'s `scanBarcode` method which is then passed into `OSBARCScannerBehaviour` in order to create the `cameraDevice` property with the selected camera. This is possible due to the `OSBARCCameraModelMappable` protocol, which allows mapping a value into the `AVCaptureDevice+Position` equivalent.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2754

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests
Regression tests updated to include the latest feature. All are passing successfully.
Manual testing was also performed to test the flow with the Sample App.

## Screenshots
https://github.com/OutSystems/OSBarcodeLib-iOS/assets/97543217/ee016a93-ec9d-4da1-bda3-df9daaaf6b28

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
