### PR TITLE
RMET-2753 ::: Add Scan Orientation Selection

### DIFF
--- a/OSBarcodeLib.xcodeproj/project.pbxproj
+++ b/OSBarcodeLib.xcodeproj/project.pbxproj
@@ -9,9 +9,17 @@
 /* Begin PBXBuildFile section */
 		7507FC1B27FC2AAE003809F6 /* OSBarcodeLib.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7507FC1227FC2AAE003809F6 /* OSBarcodeLib.framework */; };
 		750B35872AFA93B100F90083 /* OSBARCScannerViewConfigurationValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750B35862AFA93B100F90083 /* OSBARCScannerViewConfigurationValues.swift */; };
+		7513C4852B03E86B005E81C4 /* OSBARCDeviceTypeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7513C4802B03E86B005E81C4 /* OSBARCDeviceTypeModel.swift */; };
+		7513C4862B03E86B005E81C4 /* OSBARCOrientationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7513C4812B03E86B005E81C4 /* OSBARCOrientationModel.swift */; };
+		7513C4872B03E86B005E81C4 /* OSBARCDeviceTypeModelMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7513C4832B03E86B005E81C4 /* OSBARCDeviceTypeModelMappable.swift */; };
+		7513C4882B03E86B005E81C4 /* OSBARCModelMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7513C4842B03E86B005E81C4 /* OSBARCModelMappable.swift */; };
+		7513C48A2B03E8D6005E81C4 /* OSBARCScannerViewHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7513C4892B03E8D6005E81C4 /* OSBARCScannerViewHostingController.swift */; };
+		7513C48D2B03E8DF005E81C4 /* UIUserInterfaceIdiom+OSBARCModelMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7513C48B2B03E8DE005E81C4 /* UIUserInterfaceIdiom+OSBARCModelMappable.swift */; };
+		7513C48E2B03E8DF005E81C4 /* UIInterfaceOrientationMask+OSBARCModelMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7513C48C2B03E8DE005E81C4 /* UIInterfaceOrientationMask+OSBARCModelMappable.swift */; };
+		7513C4902B03E922005E81C4 /* AVCaptureVideoOrientation+CustomInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7513C48F2B03E922005E81C4 /* AVCaptureVideoOrientation+CustomInit.swift */; };
 		7554D70B2AFA3A0E00D4261C /* ToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7554D70A2AFA3A0E00D4261C /* ToggleButton.swift */; };
 		758E6C162B0238FF00FC16D9 /* OSBARCCameraModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 758E6C152B0238FF00FC16D9 /* OSBARCCameraModel.swift */; };
-		758E6C192B0239E700FC16D9 /* AVCaptureDevice+OSBARCCameraModelMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 758E6C182B0239E700FC16D9 /* AVCaptureDevice+OSBARCCameraModelMappable.swift */; };
+		758E6C192B0239E700FC16D9 /* AVCaptureDevice+OSBARCModelMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 758E6C182B0239E700FC16D9 /* AVCaptureDevice+OSBARCModelMappable.swift */; };
 		75A1FC632AFA40D200AA775F /* OSBARCScannerView.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 75A1FC622AFA40D200AA775F /* OSBARCScannerView.xcassets */; };
 		75C20B692AF4FD1900CCB5B1 /* OSBARCTestValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75C20B682AF4FD1900CCB5B1 /* OSBARCTestValues.swift */; };
 		75C20B6B2AF4FE0700CCB5B1 /* OSBARCManagerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75C20B6A2AF4FE0700CCB5B1 /* OSBARCManagerFactoryTests.swift */; };
@@ -49,9 +57,17 @@
 		7507FC1227FC2AAE003809F6 /* OSBarcodeLib.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OSBarcodeLib.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7507FC1A27FC2AAE003809F6 /* OSBarcodeLibTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OSBarcodeLibTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		750B35862AFA93B100F90083 /* OSBARCScannerViewConfigurationValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSBARCScannerViewConfigurationValues.swift; sourceTree = "<group>"; };
+		7513C4802B03E86B005E81C4 /* OSBARCDeviceTypeModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OSBARCDeviceTypeModel.swift; sourceTree = "<group>"; };
+		7513C4812B03E86B005E81C4 /* OSBARCOrientationModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OSBARCOrientationModel.swift; sourceTree = "<group>"; };
+		7513C4832B03E86B005E81C4 /* OSBARCDeviceTypeModelMappable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OSBARCDeviceTypeModelMappable.swift; sourceTree = "<group>"; };
+		7513C4842B03E86B005E81C4 /* OSBARCModelMappable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OSBARCModelMappable.swift; sourceTree = "<group>"; };
+		7513C4892B03E8D6005E81C4 /* OSBARCScannerViewHostingController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OSBARCScannerViewHostingController.swift; sourceTree = "<group>"; };
+		7513C48B2B03E8DE005E81C4 /* UIUserInterfaceIdiom+OSBARCModelMappable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIUserInterfaceIdiom+OSBARCModelMappable.swift"; sourceTree = "<group>"; };
+		7513C48C2B03E8DE005E81C4 /* UIInterfaceOrientationMask+OSBARCModelMappable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIInterfaceOrientationMask+OSBARCModelMappable.swift"; sourceTree = "<group>"; };
+		7513C48F2B03E922005E81C4 /* AVCaptureVideoOrientation+CustomInit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVCaptureVideoOrientation+CustomInit.swift"; sourceTree = "<group>"; };
 		7554D70A2AFA3A0E00D4261C /* ToggleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleButton.swift; sourceTree = "<group>"; };
 		758E6C152B0238FF00FC16D9 /* OSBARCCameraModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSBARCCameraModel.swift; sourceTree = "<group>"; };
-		758E6C182B0239E700FC16D9 /* AVCaptureDevice+OSBARCCameraModelMappable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVCaptureDevice+OSBARCCameraModelMappable.swift"; sourceTree = "<group>"; };
+		758E6C182B0239E700FC16D9 /* AVCaptureDevice+OSBARCModelMappable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVCaptureDevice+OSBARCModelMappable.swift"; sourceTree = "<group>"; };
 		75A1FC622AFA40D200AA775F /* OSBARCScannerView.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = OSBARCScannerView.xcassets; sourceTree = "<group>"; };
 		75C20B682AF4FD1900CCB5B1 /* OSBARCTestValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSBARCTestValues.swift; sourceTree = "<group>"; };
 		75C20B6A2AF4FE0700CCB5B1 /* OSBARCManagerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSBARCManagerFactoryTests.swift; sourceTree = "<group>"; };
@@ -136,10 +152,22 @@
 			path = OSBarcodeLibTests;
 			sourceTree = "<group>";
 		};
+		7513C4822B03E86B005E81C4 /* MappableProtocol */ = {
+			isa = PBXGroup;
+			children = (
+				7513C4832B03E86B005E81C4 /* OSBARCDeviceTypeModelMappable.swift */,
+				7513C4842B03E86B005E81C4 /* OSBARCModelMappable.swift */,
+			);
+			path = MappableProtocol;
+			sourceTree = "<group>";
+		};
 		758E6C142B0238F100FC16D9 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				7513C4822B03E86B005E81C4 /* MappableProtocol */,
 				758E6C152B0238FF00FC16D9 /* OSBARCCameraModel.swift */,
+				7513C4802B03E86B005E81C4 /* OSBARCDeviceTypeModel.swift */,
+				7513C4812B03E86B005E81C4 /* OSBARCOrientationModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -147,7 +175,10 @@
 		758E6C172B0239C100FC16D9 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				758E6C182B0239E700FC16D9 /* AVCaptureDevice+OSBARCCameraModelMappable.swift */,
+				758E6C182B0239E700FC16D9 /* AVCaptureDevice+OSBARCModelMappable.swift */,
+				7513C48F2B03E922005E81C4 /* AVCaptureVideoOrientation+CustomInit.swift */,
+				7513C48C2B03E8DE005E81C4 /* UIInterfaceOrientationMask+OSBARCModelMappable.swift */,
+				7513C48B2B03E8DE005E81C4 /* UIUserInterfaceIdiom+OSBARCModelMappable.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -174,6 +205,7 @@
 				75E2B1D32AF3C80C00DB689E /* OSBARCScannerViewController.swift */,
 				75E2B1D72AF3C95800DB689E /* OSBARCScannerViewControllerCoordinator.swift */,
 				75E2B1D52AF3C93200DB689E /* OSBARCScannerViewControllerRepresentable.swift */,
+				7513C4892B03E8D6005E81C4 /* OSBARCScannerViewHostingController.swift */,
 			);
 			path = Scanner;
 			sourceTree = "<group>";
@@ -349,10 +381,12 @@
 			files = (
 				75D20FEB2AF17C8E009AD84D /* OSBARCPermissionsBehaviour.swift in Sources */,
 				750B35872AFA93B100F90083 /* OSBARCScannerViewConfigurationValues.swift in Sources */,
+				7513C48A2B03E8D6005E81C4 /* OSBARCScannerViewHostingController.swift in Sources */,
+				7513C4902B03E922005E81C4 /* AVCaptureVideoOrientation+CustomInit.swift in Sources */,
 				75E2B1CD2AF3AC5500DB689E /* OSBARCScannerBehaviour.swift in Sources */,
 				75E2B1C72AF3A99A00DB689E /* OSBARCScannerView.swift in Sources */,
 				75E2B1CF2AF3ACE900DB689E /* OSBARCScannerProtocol.swift in Sources */,
-				758E6C192B0239E700FC16D9 /* AVCaptureDevice+OSBARCCameraModelMappable.swift in Sources */,
+				758E6C192B0239E700FC16D9 /* AVCaptureDevice+OSBARCModelMappable.swift in Sources */,
 				75D20FE92AF17C1C009AD84D /* OSBARCPermissionsProtocol.swift in Sources */,
 				75D20FE52AF17A87009AD84D /* OSBARCCoordinator.swift in Sources */,
 				75D20FE72AF17AFC009AD84D /* OSBARCCoordinatorProtocol.swift in Sources */,
@@ -361,11 +395,17 @@
 				75E2B1D42AF3C80C00DB689E /* OSBARCScannerViewController.swift in Sources */,
 				75E2B1D62AF3C93200DB689E /* OSBARCScannerViewControllerRepresentable.swift in Sources */,
 				7554D70B2AFA3A0E00D4261C /* ToggleButton.swift in Sources */,
+				7513C48D2B03E8DF005E81C4 /* UIUserInterfaceIdiom+OSBARCModelMappable.swift in Sources */,
 				75E2B20F2AF41B5000DB689E /* View+StyleForColour.swift in Sources */,
 				75E2B1D22AF3AE1200DB689E /* OSBARCCoordinatable.swift in Sources */,
 				75E2B1D82AF3C95800DB689E /* OSBARCScannerViewControllerCoordinator.swift in Sources */,
 				758E6C162B0238FF00FC16D9 /* OSBARCCameraModel.swift in Sources */,
+				7513C48E2B03E8DF005E81C4 /* UIInterfaceOrientationMask+OSBARCModelMappable.swift in Sources */,
 				75D20FDF2AF16AE4009AD84D /* OSBARCManagerProtocol.swift in Sources */,
+				7513C4872B03E86B005E81C4 /* OSBARCDeviceTypeModelMappable.swift in Sources */,
+				7513C4882B03E86B005E81C4 /* OSBARCModelMappable.swift in Sources */,
+				7513C4862B03E86B005E81C4 /* OSBARCOrientationModel.swift in Sources */,
+				7513C4852B03E86B005E81C4 /* OSBARCDeviceTypeModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OSBarcodeLib/Manager/OSBARCManager.swift
+++ b/OSBarcodeLib/Manager/OSBARCManager.swift
@@ -33,13 +33,13 @@ struct OSBARCManager {
 
 /// Implementation of the `OSBARCManagerProtocol` methods.
 extension OSBARCManager: OSBARCManagerProtocol {
-    func scanBarcode(with instructionsText: String, _ buttonText: String?, and cameraModel: OSBARCCameraModel) async throws -> String {
+    func scanBarcode(with instructionsText: String, _ buttonText: String?, _ cameraModel: OSBARCCameraModel, and orientationModel: OSBARCOrientationModel) async throws -> String {
         // validates if the user has access to the device's camera.
         let hasCameraAccess = await self.permissionsBehaviour.hasCameraAccess()
         if !hasCameraAccess { throw OSBARCManagerError.cameraAccessDenied }
         // requests the scanner to start, treating its result value.
         return try await withCheckedThrowingContinuation {
-            self.startScanning(with: instructionsText, buttonText, and: cameraModel, continuation: $0)
+            self.startScanning(with: instructionsText, buttonText, cameraModel, and: orientationModel, continuation: $0)
         }
     }
     
@@ -47,11 +47,18 @@ extension OSBARCManager: OSBARCManagerProtocol {
     /// - Parameters:
     ///   - instructionsText: Text to be displayed on the scanner view.
     ///   - buttonText: Text to be displayed for the scan button, if this is configured. `Nil` value means that the button will not be shown.
-    ///   - continuation: Object responsible for returning the method's result to its caller.
     ///   - cameraModel: Camera to use for input gathering.
-    private func startScanning(with instructionsText: String, _ buttonText: String?, and cameraModel: OSBARCCameraModel, continuation: CheckedContinuation<String, any Error>) {
+    ///   - orientationModel: Scanner view's orientation.
+    ///   - continuation: Object responsible for returning the method's result to its caller.
+    private func startScanning(
+        with instructionsText: String,
+        _ buttonText: String?,
+        _ cameraModel: OSBARCCameraModel,
+        and orientationModel: OSBARCOrientationModel,
+        continuation: CheckedContinuation<String, any Error>
+    ) {
         DispatchQueue.main.async {
-            self.scannerBehaviour.startScanning(with: instructionsText, buttonText, and: cameraModel) { scannedCode in
+            self.scannerBehaviour.startScanning(with: instructionsText, buttonText, cameraModel, and: orientationModel) { scannedCode in
                 if !scannedCode.isEmpty {
                     continuation.resume(returning: scannedCode)
                 } else {

--- a/OSBarcodeLib/Manager/OSBARCManagerProtocol.swift
+++ b/OSBarcodeLib/Manager/OSBARCManagerProtocol.swift
@@ -8,6 +8,7 @@ public protocol OSBARCManagerProtocol {
     ///   - instructionsText: Text to be displayed on the scanner view.
     ///   - buttonText: Text to be displayed for the scan button, if this is configured. `Nil` value means that the button will not be shown.
     ///   - cameraModel: Camera to use for input gathering.
+    ///   - orientationModel: Scanner view's orientation.
     /// - Returns: When successful, it returns the text associated with the scanned barcode.
-    func scanBarcode(with instructionsText: String, _ buttonText: String?, and cameraModel: OSBARCCameraModel) async throws -> String
+    func scanBarcode(with instructionsText: String, _ buttonText: String?, _ cameraModel: OSBARCCameraModel, and orientationModel: OSBARCOrientationModel) async throws -> String
 }

--- a/OSBarcodeLib/Models/MappableProtocol/OSBARCDeviceTypeModelMappable.swift
+++ b/OSBarcodeLib/Models/MappableProtocol/OSBARCDeviceTypeModelMappable.swift
@@ -1,0 +1,5 @@
+/// Provides a mapping from a structure or class to an object of `OSBARCDeviceTypeModel` type.
+protocol OSBARCDeviceTypeModelMappable {
+    /// Identifies the type of the device where the plugin is currently running on.
+    var deviceTypeModel: OSBARCDeviceTypeModel { get }
+}

--- a/OSBarcodeLib/Models/MappableProtocol/OSBARCModelMappable.swift
+++ b/OSBarcodeLib/Models/MappableProtocol/OSBARCModelMappable.swift
@@ -1,0 +1,9 @@
+/// Allows mapping a to be defined `Model` to whatever class that it implements the protocol.
+protocol OSBARCModelMappable {
+    /// Type to use with the `map(_:)` method.
+    associatedtype Model
+    /// Maps an `Model` object into an object of the type of the class it implements
+    /// - Parameter value: Value to map.
+    /// - Returns: Resulting mapped value.
+    static func map(_ value: Model) -> Self
+}

--- a/OSBarcodeLib/Models/OSBARCCameraModel.swift
+++ b/OSBarcodeLib/Models/OSBARCCameraModel.swift
@@ -3,11 +3,3 @@ public enum OSBARCCameraModel {
     case back
     case front
 }
-
-/// Allows mapping a `OSBARCCameraModel` to whatever class that it implements the protocol.
-protocol OSBARCCameraModelMappable {
-    /// Maps an `OSBARCCameraModel` object into an object of the type of the class it implements
-    /// - Parameter value: Value to map.
-    /// - Returns: Resulting mapped value.
-    static func map(_ value: OSBARCCameraModel) -> Self
-}

--- a/OSBarcodeLib/Models/OSBARCDeviceTypeModel.swift
+++ b/OSBarcodeLib/Models/OSBARCDeviceTypeModel.swift
@@ -1,0 +1,5 @@
+/// Enumerator with the possible device types the plugin can run on.
+enum OSBARCDeviceTypeModel {
+    case ipad
+    case iphone
+}

--- a/OSBarcodeLib/Models/OSBARCOrientationModel.swift
+++ b/OSBarcodeLib/Models/OSBARCOrientationModel.swift
@@ -1,0 +1,6 @@
+/// Enumerator with the possible orientations the scanner view can assume.
+public enum OSBARCOrientationModel {
+    case adaptive
+    case landscape
+    case portrait
+}

--- a/OSBarcodeLib/Scanner/Extensions/AVCaptureDevice+OSBARCModelMappable.swift
+++ b/OSBarcodeLib/Scanner/Extensions/AVCaptureDevice+OSBARCModelMappable.swift
@@ -1,5 +1,5 @@
 import AVFoundation
 
-extension AVCaptureDevice.Position: OSBARCCameraModelMappable {
+extension AVCaptureDevice.Position: OSBARCModelMappable {
     static func map(_ value: OSBARCCameraModel) -> AVCaptureDevice.Position { value == .front ? .front : back }
 }

--- a/OSBarcodeLib/Scanner/Extensions/AVCaptureVideoOrientation+CustomInit.swift
+++ b/OSBarcodeLib/Scanner/Extensions/AVCaptureVideoOrientation+CustomInit.swift
@@ -1,0 +1,17 @@
+import AVFoundation
+import UIKit
+
+/// Extension that maps a `UIDeviceOrientation` into an `AVCaptureVideoOrientation`.
+extension AVCaptureVideoOrientation {
+    /// Mapper construtor.
+    /// - Parameter deviceOrientation: Value to be converted from.
+    init?(deviceOrientation: UIDeviceOrientation) {
+        switch deviceOrientation {
+        case .portrait: self = .portrait
+        case .portraitUpsideDown: self = .portraitUpsideDown
+        case .landscapeLeft: self = .landscapeRight
+        case .landscapeRight: self = .landscapeLeft
+        default: return nil
+        }
+    }
+}

--- a/OSBarcodeLib/Scanner/Extensions/UIInterfaceOrientationMask+OSBARCModelMappable.swift
+++ b/OSBarcodeLib/Scanner/Extensions/UIInterfaceOrientationMask+OSBARCModelMappable.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+extension UIInterfaceOrientationMask: OSBARCModelMappable {
+    static var deviceTypeModel: OSBARCDeviceTypeModel { UIDevice.current.userInterfaceIdiom.deviceTypeModel }
+    
+    static func map(_ value: OSBARCOrientationModel) -> UIInterfaceOrientationMask {
+        switch value {
+        case .portrait: return .portrait
+        case .landscape: return .landscape
+        default: return Self.deviceTypeModel == .iphone ? .allButUpsideDown : .all
+        }
+    }
+}

--- a/OSBarcodeLib/Scanner/Extensions/UIUserInterfaceIdiom+OSBARCModelMappable.swift
+++ b/OSBarcodeLib/Scanner/Extensions/UIUserInterfaceIdiom+OSBARCModelMappable.swift
@@ -1,0 +1,5 @@
+import UIKit
+
+extension UIUserInterfaceIdiom: OSBARCDeviceTypeModelMappable {
+    var deviceTypeModel: OSBARCDeviceTypeModel { self == .phone ? .iphone : .ipad }
+}

--- a/OSBarcodeLib/Scanner/OSBARCScannerBehaviour.swift
+++ b/OSBarcodeLib/Scanner/OSBARCScannerBehaviour.swift
@@ -10,7 +10,7 @@ final class OSBARCScannerBehaviour: OSBARCCoordinatable, OSBARCScannerProtocol {
     /// The publisher's cancellable instance collector.
     private var cancellables: Set<AnyCancellable> = []
     
-    func startScanning(with instructionsText: String, _ buttonText: String?, and cameraModel: OSBARCCameraModel, _ completion: @escaping (String) -> Void) {
+    func startScanning(with instructionsText: String, _ buttonText: String?, _ cameraModel: OSBARCCameraModel, and orientationModel: OSBARCOrientationModel, _ completion: @escaping (String) -> Void) {
         $scanResult
             .dropFirst()    // drops the first value - the empty string
             .first()        // only publishes the first barcode value found
@@ -41,9 +41,11 @@ final class OSBARCScannerBehaviour: OSBARCCoordinatable, OSBARCScannerProtocol {
             cameraHasTorch: cameraHasTorch,
             instructionsText: instructionsText,
             buttonText: buttonText,
-            shouldShowButton: !buttonText.isEmpty   // if empty text is passed, the button is not enabled on the scanner view.
+            shouldShowButton: !buttonText.isEmpty,  // if empty text is passed, the button is not enabled on the scanner view.
+            orientationModel: orientationModel
         )
-        let hostingController = UIHostingController(rootView: scannerView)
+        let hostingController = OSBARCScannerViewHostingController(rootView: scannerView, orientationModel)
+        hostingController.modalPresentationStyle = .fullScreen
         
         self.coordinator.present(hostingController)
     }

--- a/OSBarcodeLib/Scanner/OSBARCScannerProtocol.swift
+++ b/OSBarcodeLib/Scanner/OSBARCScannerProtocol.swift
@@ -4,7 +4,8 @@ protocol OSBARCScannerProtocol {
     /// - Parameters:
     ///   - instructionsText: Text to be displayed on the scanner view.
     ///   - buttonText: Text to be displayed for the scan button, if this is configured. `Nil` value means that the button will not be shown.
-    ///   - completion: The value returned or empty string in case the view is closed with no code scanned.
     ///   - cameraModel: Camera to use for input gathering.
-    func startScanning(with instructionsText: String, _ buttonText: String?, and cameraModel: OSBARCCameraModel, _ completion: @escaping (String) -> Void)
+    ///   - orientationModel: Scanner view's orientation.
+    ///   - completion: The value returned or empty string in case the view is closed with no code scanned.
+    func startScanning(with instructionsText: String, _ buttonText: String?, _ cameraModel: OSBARCCameraModel, and orientationModel: OSBARCOrientationModel, _ completion: @escaping (String) -> Void)
 }

--- a/OSBarcodeLib/Scanner/OSBARCScannerView.swift
+++ b/OSBarcodeLib/Scanner/OSBARCScannerView.swift
@@ -24,10 +24,13 @@ struct OSBARCScannerView: View {
     /// Indicates if scanning is enabled. It's only applied when there's a Scan Button visible (otherwise, scanning is automatically).
     @State var buttonScanEnabled: Bool = false
     
+    /// Orientation the screen should adapt to.
+    let orientationModel: OSBARCOrientationModel
+    
     var body: some View {
         ZStack(alignment: .topTrailing) {
             // Camera Stream
-            OSBARCScannerViewControllerRepresentable(captureDevice, $scanResult, shouldShowButton, $buttonScanEnabled)
+            OSBARCScannerViewControllerRepresentable(captureDevice, $scanResult, shouldShowButton, $buttonScanEnabled, orientationModel)
             
             VStack {
                 HStack {

--- a/OSBarcodeLib/Scanner/OSBARCScannerViewControllerRepresentable.swift
+++ b/OSBarcodeLib/Scanner/OSBARCScannerViewControllerRepresentable.swift
@@ -4,35 +4,36 @@ import SwiftUI
 /// Structure responsible for bridging `OSBARCScannerViewController` into SwiftUI.
 struct OSBARCScannerViewControllerRepresentable: UIViewControllerRepresentable {
     /// The camera used to capture video for barcode scanning.
-    var captureDevice: AVCaptureDevice?
+    private var captureDevice: AVCaptureDevice?
     
     /// The object containing the value to return.
-    @Binding var scanResult: String
+    @Binding private var scanResult: String
     
     /// Indicates if scanning should be done only after a button click or automatically.
-    var scanThroughButton: Bool
+    private var scanThroughButton: Bool
     /// Indicates if scanning is enabled (when there's a Scan Button).
-    @Binding var scanButtonEnabled: Bool
+    @Binding private var scanButtonEnabled: Bool
     
-    /// Construtor method.
+    /// Orientation the screen should adapt to.
+    private var orientationModel: OSBARCOrientationModel
+    
+    /// Constructor method.
     /// - Parameters:
     ///   - captureDevice: The camera used to capture video for barcode scanning.
     ///   - scanResult: The object containing the value to return.
     ///   - scanThroughButton: Indicates if scanning should be done only after a button click or automatically.
     ///   - scanButtonEnabled: Indicates if scanning is enabled (when there's a Scan Button).
-    init(_ captureDevice: AVCaptureDevice?, _ scanResult: Binding<String>, _ scanThroughButton: Bool, _ scanButtonEnabled: Binding<Bool>) {
+    ///   - orientationModel: Orientation the screen should adapt to.
+    init(_ captureDevice: AVCaptureDevice?, _ scanResult: Binding<String>, _ scanThroughButton: Bool, _ scanButtonEnabled: Binding<Bool>, _ orientationModel: OSBARCOrientationModel) {
         self.captureDevice = captureDevice
         self._scanResult = scanResult
         self.scanThroughButton = scanThroughButton
         self._scanButtonEnabled = scanButtonEnabled
+        self.orientationModel = orientationModel
     }
     
     func makeUIViewController(context: Context) -> OSBARCScannerViewController {
-        let controller = OSBARCScannerViewController()
-        controller.delegate = context.coordinator
-        controller.captureDevice = captureDevice
-        
-        return controller
+        .init(delegate: context.coordinator, captureDevice: captureDevice, orientationModel: orientationModel)
     }
     
     func updateUIViewController(_ uiViewController: OSBARCScannerViewController, context: Context) {

--- a/OSBarcodeLib/Scanner/OSBARCScannerViewHostingController.swift
+++ b/OSBarcodeLib/Scanner/OSBARCScannerViewHostingController.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// Class that hosts the `OSBARCScannerView` SwiftUI view.
+class OSBARCScannerViewHostingController<Content>: UIHostingController<Content> where Content: View {
+    /// Orientation the screen should adapt to.
+    private var orientationModel: OSBARCOrientationModel
+    
+    /// Constructor method.
+    /// - Parameters:
+    ///   - rootView: The root view of the SwiftUI view hierarchy that you want to manage using the hosting view controller
+    ///   - orientationModel: Orientation the screen should adapt to.
+    init(rootView: Content, _ orientationModel: OSBARCOrientationModel) {
+        self.orientationModel = orientationModel
+        super.init(rootView: rootView)
+    }
+    
+    /// Required method.. This is not used.
+    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask { .map(self.orientationModel) }
+}

--- a/OSBarcodeLibTests/OSBARCManagerTests.swift
+++ b/OSBarcodeLibTests/OSBARCManagerTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 private extension OSBARCManager {
     func scanBarcode() async throws -> String {
-        // `instructionText`, `buttonText` and `cameraModel` are UI-related so are irrelevant for the unit tests.
-        try await self.scanBarcode(with: "Instruction Text", "Scan Button", and: .back)
+        // `instructionText`, `buttonText`, `cameraModel` and `orientationModel` are UI-related so are irrelevant for the unit tests.
+        try await self.scanBarcode(with: "Instruction Text", "Scan Button", .back, and: .adaptive)
     }
 }
 

--- a/OSBarcodeLibTests/Stubs/OSBARCScannerStub.swift
+++ b/OSBarcodeLibTests/Stubs/OSBARCScannerStub.swift
@@ -3,7 +3,13 @@
 final class OSBARCScannerStub: OSBARCScannerProtocol {
     var scanCancelled: Bool = false
     
-    func startScanning(with instructionsText: String, _ buttonText: String?, and cameraModel: OSBARCCameraModel, _ completion: @escaping (String) -> Void) {
+    func startScanning(
+        with instructionsText: String,
+        _ buttonText: String?,
+        _ cameraModel: OSBARCCameraModel,
+        and orientationModel: OSBARCOrientationModel,
+        _ completion: @escaping (String) -> Void
+    ) {
         completion(self.scanCancelled ? "" : OSBARCScannerStubValues.scannedCode)
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+- Add Scan Orientation Selection feature (https://outsystemsrd.atlassian.net/browse/RMET-2753).
 - Add Camera Selection feature (https://outsystemsrd.atlassian.net/browse/RMET-2754).
 - Add Scan Button feature (https://outsystemsrd.atlassian.net/browse/RMET-2752).
 - Add Scan Instruction text feature (https://outsystemsrd.atlassian.net/browse/RMET-2751).


### PR DESCRIPTION
## Description
Add a new `OSBARCOrientationModel` enumerator to deal with the possible values regarding orientation. Since this value is provided by the Cordova Wrapper, a parameter of this type needs to be added to the `OSBARCManagerProtocol`'s `scanBarcode` method and passed until the `OSBARCScannerBehaviour` for UI purposes.

In order for the Scanner view to display the correct orientation, a subclass of `UIHostingController` needs to be added and its presentation style changed to `fullScreen`. This is achieved by creating and calling the new `OSBARCScannnerViewHostingController`.

Add `OSBARCDeviceTypeModel` enumerator and `OSBARCDeviceTypeModelMappable` protocol. This is needed for the `adaptive` orientation, where the orientations to respond to depend on the type of device.

Adjust `OSBARCScannerViewController` so that the video orientation adjusts to the selected orientation, not only when opening but also after rotating the device.

Make the `OSBARCCameraModelMappable` protocol generic so that it can be used by other models. The protocol is now called `OSBARCModelMappable`.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2753

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests
Regression tests updated to include the latest feature. All are passing successfully.
Manual testing was also performed to test the flow with the Sample App.

## Screenshots
### Adaptive
https://github.com/OutSystems/OSBarcodeLib-iOS/assets/97543217/d3b53763-8749-475f-9b51-06e02e52ede2

### Portrait
https://github.com/OutSystems/OSBarcodeLib-iOS/assets/97543217/f568e53c-fa36-43b6-b14b-d679e421fff3

### Landscape
https://github.com/OutSystems/OSBarcodeLib-iOS/assets/97543217/96a75a09-092f-4c18-9a1b-69581cd06050

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
