### PR TITLE
RMET-2771, 2911 ::: Filter Scanning View

### DIFF
--- a/OSBarcodeLib.xcodeproj/project.pbxproj
+++ b/OSBarcodeLib.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		7513C48E2B03E8DF005E81C4 /* UIInterfaceOrientationMask+OSBARCModelMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7513C48C2B03E8DE005E81C4 /* UIInterfaceOrientationMask+OSBARCModelMappable.swift */; };
 		7513C4902B03E922005E81C4 /* AVCaptureVideoOrientation+CustomInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7513C48F2B03E922005E81C4 /* AVCaptureVideoOrientation+CustomInit.swift */; };
 		7554D70B2AFA3A0E00D4261C /* OSBARCTorchButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7554D70A2AFA3A0E00D4261C /* OSBARCTorchButton.swift */; };
+		75562B3D2B17676D00F31AF6 /* Notification+ScanFrameChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75562B3C2B17676D00F31AF6 /* Notification+ScanFrameChanged.swift */; };
+		75562B3F2B1767C100F31AF6 /* UIApplication+Window.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75562B3E2B1767C100F31AF6 /* UIApplication+Window.swift */; };
 		758E6C162B0238FF00FC16D9 /* OSBARCCameraModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 758E6C152B0238FF00FC16D9 /* OSBARCCameraModel.swift */; };
 		758E6C192B0239E700FC16D9 /* AVCaptureDevice+OSBARCModelMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 758E6C182B0239E700FC16D9 /* AVCaptureDevice+OSBARCModelMappable.swift */; };
 		75A1FC632AFA40D200AA775F /* OSBARCScannerView.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 75A1FC622AFA40D200AA775F /* OSBARCScannerView.xcassets */; };
@@ -71,6 +73,8 @@
 		7513C48C2B03E8DE005E81C4 /* UIInterfaceOrientationMask+OSBARCModelMappable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIInterfaceOrientationMask+OSBARCModelMappable.swift"; sourceTree = "<group>"; };
 		7513C48F2B03E922005E81C4 /* AVCaptureVideoOrientation+CustomInit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVCaptureVideoOrientation+CustomInit.swift"; sourceTree = "<group>"; };
 		7554D70A2AFA3A0E00D4261C /* OSBARCTorchButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSBARCTorchButton.swift; sourceTree = "<group>"; };
+		75562B3C2B17676D00F31AF6 /* Notification+ScanFrameChanged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+ScanFrameChanged.swift"; sourceTree = "<group>"; };
+		75562B3E2B1767C100F31AF6 /* UIApplication+Window.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+Window.swift"; sourceTree = "<group>"; };
 		758E6C152B0238FF00FC16D9 /* OSBARCCameraModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSBARCCameraModel.swift; sourceTree = "<group>"; };
 		758E6C182B0239E700FC16D9 /* AVCaptureDevice+OSBARCModelMappable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVCaptureDevice+OSBARCModelMappable.swift"; sourceTree = "<group>"; };
 		75A1FC622AFA40D200AA775F /* OSBARCScannerView.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = OSBARCScannerView.xcassets; sourceTree = "<group>"; };
@@ -186,6 +190,8 @@
 			children = (
 				758E6C182B0239E700FC16D9 /* AVCaptureDevice+OSBARCModelMappable.swift */,
 				7513C48F2B03E922005E81C4 /* AVCaptureVideoOrientation+CustomInit.swift */,
+				75562B3C2B17676D00F31AF6 /* Notification+ScanFrameChanged.swift */,
+				75562B3E2B1767C100F31AF6 /* UIApplication+Window.swift */,
 				7513C48C2B03E8DE005E81C4 /* UIInterfaceOrientationMask+OSBARCModelMappable.swift */,
 				7513C48B2B03E8DE005E81C4 /* UIUserInterfaceIdiom+OSBARCModelMappable.swift */,
 				75E2B20E2AF41B5000DB689E /* View+CustomModifiers.swift */,
@@ -404,6 +410,7 @@
 				758E6C192B0239E700FC16D9 /* AVCaptureDevice+OSBARCModelMappable.swift in Sources */,
 				75D20FE92AF17C1C009AD84D /* OSBARCPermissionsProtocol.swift in Sources */,
 				75D20FE52AF17A87009AD84D /* OSBARCCoordinator.swift in Sources */,
+				75562B3F2B1767C100F31AF6 /* UIApplication+Window.swift in Sources */,
 				75D20FE72AF17AFC009AD84D /* OSBARCCoordinatorProtocol.swift in Sources */,
 				75D20FE22AF16B0A009AD84D /* OSBARCManagerFactory.swift in Sources */,
 				75EF59A42B0E4A410084F144 /* OSBARCScanButton.swift in Sources */,
@@ -420,6 +427,7 @@
 				7513C48E2B03E8DF005E81C4 /* UIInterfaceOrientationMask+OSBARCModelMappable.swift in Sources */,
 				75D20FDF2AF16AE4009AD84D /* OSBARCManagerProtocol.swift in Sources */,
 				75EF599E2B0E31620084F144 /* OSBARCCancelButton.swift in Sources */,
+				75562B3D2B17676D00F31AF6 /* Notification+ScanFrameChanged.swift in Sources */,
 				7513C4872B03E86B005E81C4 /* OSBARCDeviceTypeModelMappable.swift in Sources */,
 				75EF59A02B0E44660084F144 /* OSBARCInstructionsText.swift in Sources */,
 				7513C4882B03E86B005E81C4 /* OSBARCModelMappable.swift in Sources */,

--- a/OSBarcodeLib/Scanner/Extensions/Notification+ScanFrameChanged.swift
+++ b/OSBarcodeLib/Scanner/Extensions/Notification+ScanFrameChanged.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+extension Notification.Name {
+    /// Notification triggered when barcode's scan frame gets changed.
+    static let scanFrameChanged = Notification.Name("scanFrameChanged")
+}

--- a/OSBarcodeLib/Scanner/Extensions/UIApplication+Window.swift
+++ b/OSBarcodeLib/Scanner/Extensions/UIApplication+Window.swift
@@ -1,0 +1,12 @@
+import UIKit
+
+extension UIApplication {
+    /// The application's main window.
+    static var firstKeyWindowForConnectedScenes: UIWindow? {
+        UIApplication
+            .shared
+            .connectedScenes
+            .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
+            .last { $0.isKeyWindow }
+    }
+}

--- a/OSBarcodeLib/Scanner/Extensions/View+CustomModifiers.swift
+++ b/OSBarcodeLib/Scanner/Extensions/View+CustomModifiers.swift
@@ -1,3 +1,4 @@
+import Combine
 import SwiftUI
 
 extension View {
@@ -35,6 +36,20 @@ extension View {
             self.ignoresSafeArea()
         } else {
             self.edgesIgnoringSafeArea(.all)
+        }
+    }
+    
+    /// Adds a modifier for this view that fires an action when a specific value changes.
+    /// - Parameters:
+    ///   - value: The value to check against when determining whether to run the closure.
+    ///   - onChange: A closure to run when the value changes.
+    /// - Returns: A view that fires an action when the specified value changes.
+    @ViewBuilder
+    func valueChanged<T: Equatable>(value: T, _ onChange: @escaping (T) -> Void) -> some View {
+        if #available(iOS 14.0, *) {
+            self.onChange(of: value, perform: onChange)
+        } else {
+            self.onReceive(Just(value)) { onChange($0) }
         }
     }
 }

--- a/OSBarcodeLib/Scanner/Interface Elements/OSBARCBackgroundView.swift
+++ b/OSBarcodeLib/Scanner/Interface Elements/OSBARCBackgroundView.swift
@@ -3,29 +3,22 @@ import SwiftUI
 /// Background view that is displayed behind the interface elements (a black view with a little transparency).
 /// Since the view has a "hole" in the middle, in reality is composed by 4 rectangles, one for each side of the hole.
 struct OSBARCBackgroundView: View {
-    /// The smallest size (height/width) to be used to draw the side rectangle
-    let padding: CGFloat
-    /// The biggest size (height/width) to be used to draw the side rectangle.
-    let size: CGSize
+    /// Frame of portion of the screen used for scanning.
+    let scanFrame: CGRect
     
     /// Colour to be displayed as the background.
     private let colour: Color = OSBARCScannerViewConfigurationValues.backgroundColour
+    /// Radius to apply on the vertices.
+    private let radius: CGFloat = OSBARCScannerViewConfigurationValues.defaultRadius
     
-    var body: some View {
-        // left side
-        colour
-            .frame(width: padding, height: size.height)
-        // right side
-        colour
-            .frame(width: padding, height: size.height)
-            .offset(x: size.width - padding)
-        // top side
-        colour
-            .frame(width: size.width - padding * 2.0, height: padding)
-            .offset(x: padding)
-        // bottom side
-        colour
-            .frame(width: size.width - padding * 2.0, height: padding)
-            .offset(x: padding, y: size.height - padding)
+    var body: some View {        
+        ZStack(alignment: .topLeading) {
+            colour
+            
+            RoundedRectangle(cornerRadius: radius)
+                .blendMode(.destinationOut)
+                .offset(x: scanFrame.minX, y: scanFrame.minY)
+                .frame(width: scanFrame.width, height: scanFrame.height)
+        }.compositingGroup()
     }
 }

--- a/OSBarcodeLib/Scanner/Interface Elements/OSBARCInstructionsText.swift
+++ b/OSBarcodeLib/Scanner/Interface Elements/OSBARCInstructionsText.swift
@@ -7,14 +7,11 @@ struct OSBARCInstructionsText: View {
     
     /// The colour to be used for the font.
     private let foregroundColour: Color = OSBARCScannerViewConfigurationValues.mainColour
-    /// The colour to be used as the text's background.
-    private let backgroundColour: Color = OSBARCScannerViewConfigurationValues.backgroundColour
     
     var body: some View {
         Text(instructionsText)
             .foregroundStyle(forColour: foregroundColour)
             .fixedSize(horizontal: false, vertical: true)   // allows the text to grow vertically in case of multiline text.
             .frame(maxWidth: .infinity, alignment: .center) // allows the text to grow horizontally, centering it on the view it's inserted on.
-            .background(backgroundColour)
     }
 }

--- a/OSBarcodeLib/Scanner/Interface Elements/OSBARCScanningZone.swift
+++ b/OSBarcodeLib/Scanner/Interface Elements/OSBARCScanningZone.swift
@@ -6,7 +6,7 @@ struct OSBARCScanningZone: View {
     /// The size of the scanning zone.
     let size: CGSize
     
-    /// Considering the aim outside is a Rounded Rectangle, this is the radius its vertices.
+    /// Considering the aim outside is a Rounded Rectangle, this is the radius of its vertices.
     private let radius: CGFloat = OSBARCScannerViewConfigurationValues.defaultRadius
     /// The colour of the aim's line.
     private let color: Color = OSBARCScannerViewConfigurationValues.mainColour

--- a/OSBarcodeLib/Scanner/OSBARCScannerViewController.swift
+++ b/OSBarcodeLib/Scanner/OSBARCScannerViewController.swift
@@ -5,17 +5,17 @@ import UIKit
 /// Class responsible for displaying the camera stream that performs the scanning.
 final class OSBARCScannerViewController: UIViewController {
     /// Object that coordinates the follow between the input device to the capture output.
-    private var captureSession = AVCaptureSession()
+    private let captureSession = AVCaptureSession()
     /// Layer that displays video from the device's camera.
     private var videoPreviewLayer: AVCaptureVideoPreviewLayer?
     
     /// Object that manages the reception of sample buffers from a video data output.
-    private var delegate: AVCaptureVideoDataOutputSampleBufferDelegate?
+    private let delegate: AVCaptureVideoDataOutputSampleBufferDelegate?
     /// The camera used to capture video for barcode scanning.
-    private var captureDevice: AVCaptureDevice?
+    private let captureDevice: AVCaptureDevice?
     
     /// Orientation the screen should adapt to.
-    private var orientationModel: OSBARCOrientationModel
+    private let orientationModel: OSBARCOrientationModel
     
     /// Constructor method
     /// - Parameters:
@@ -87,12 +87,14 @@ final class OSBARCScannerViewController: UIViewController {
              If the orientation has to be portrait but the device is not on that mode, orientation is set to `portrait`.
              If the orientation has to be landscape but the device is not on that mode, orientation is set to `landscapeRight`.
              
-             If the device is set to `flat` orientation, then `portrait` is used for the video orientation.
+             If the device is set to `flat` orientation, then check screen size to understand it's portrait or landscape.
              */
             if self.orientationModel == .portrait, !deviceOrientation.isPortrait {
                 initialVideoOrientation = .portrait
             } else if self.orientationModel == .landscape, !deviceOrientation.isLandscape {
                 initialVideoOrientation = .landscapeRight
+            } else if let screenBounds = self.view.window?.windowScene?.screen.bounds {
+                initialVideoOrientation = screenBounds.width > screenBounds.height ? .landscapeRight : .portrait
             }
             
             self.videoPreviewLayer?.connection?.videoOrientation = initialVideoOrientation ?? .portrait

--- a/OSBarcodeLib/Scanner/OSBARCScannerViewControllerCoordinator.swift
+++ b/OSBarcodeLib/Scanner/OSBARCScannerViewControllerCoordinator.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import Combine
 import SwiftUI
 import Vision
 
@@ -7,9 +8,12 @@ final class OSBARCScannerViewControllerCoordinator: NSObject, AVCaptureVideoData
     /// The object containing the value to return.
     @Binding private var scanResult: String
     /// Indicates if scanning should be done only  after a button click or automatically.
-    private var scanThroughButton: Bool
+    private let scanThroughButton: Bool
     /// Indicates if scanning is enabled (when there's a Scan Button).
     @Binding private var scanButtonEnabled: Bool
+    
+    /// The publisher's cancellable instance collector.
+    private var cancellables: Set<AnyCancellable> = []
     
     /// List of barcode types the scanner is looking for.
     lazy private var barcodeTypes: [VNBarcodeSymbology] = {
@@ -29,6 +33,17 @@ final class OSBARCScannerViewControllerCoordinator: NSObject, AVCaptureVideoData
         self._scanResult = scanResult
         self.scanThroughButton = scanThroughButton
         self._scanButtonEnabled = scanButtonEnabled
+        super.init()
+        
+        NotificationCenter.default
+            .publisher(for: .scanFrameChanged)
+            .receive(on: RunLoop.main)  // receive this on the main thread
+            .sink { // performed this when `scanFrameChanged` gets triggered (on screen rotation).
+                if let imageRect = $0.object as? CGRect, let regionOfInterest = self.scanRegionOfInterest(for: imageRect) {
+                    self.detectBarcodeRequest.regionOfInterest = regionOfInterest   // update `regionOfInterest`
+                }
+            }
+            .store(in: &cancellables)
     }
     
     func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
@@ -42,7 +57,9 @@ final class OSBARCScannerViewControllerCoordinator: NSObject, AVCaptureVideoData
             requestOptions = [.cameraIntrinsics: camData]
         }
         
-        let imageRequestHandler = VNImageRequestHandler(cvPixelBuffer: pixelBuffer, orientation: .up, options: requestOptions)
+        let imageRequestHandler = VNImageRequestHandler(
+            cvPixelBuffer: pixelBuffer, orientation: self.deviceExifOrientation(), options: requestOptions
+        )
         try? imageRequestHandler.perform([self.detectBarcodeRequest])
     }
     
@@ -56,15 +73,47 @@ final class OSBARCScannerViewControllerCoordinator: NSObject, AVCaptureVideoData
         
         return barcodeRequest
     }()
-    
+}
+
+// MARK: - Private coordinator methods
+private extension OSBARCScannerViewControllerCoordinator {
     /// Processes the Vision request to return the desired barcode value.
     /// - Parameter request: Vision request handler that performs image analysis.
-    private func processClassification(for request: VNRequest) {
+    func processClassification(for request: VNRequest) {
         DispatchQueue.main.async {
             if let bestResult = request.results?.first as? VNBarcodeObservation, let payload = bestResult.payloadStringValue {
                 AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
                 self.scanResult = payload
             }
+        }
+    }
+    
+    /// Projects a rectangle from image coordinates into normalized coordinates.
+    /// The normalized coordinates is the format expected by Vision's Region of Interest.
+    /// More detail on https://developer.apple.com/documentation/vision/vnimagebasedrequest/2877482-regionofinterest.
+    /// - Parameter imageRect: The coordinates to convert
+    /// - Returns: The converted coordinates. If can return `nil` if not able to fetch the screens bounds to base on.
+    func scanRegionOfInterest(for imageRect: CGRect) -> CGRect? {
+        guard let screenBounds = UIApplication.firstKeyWindowForConnectedScenes?.windowScene?.screen.bounds else { return nil }
+        return VNNormalizedRectForImageRect(imageRect, Int(screenBounds.width), Int(screenBounds.height))
+    }
+    
+    /// Converts device orientation into the intended image's display orientation.
+    /// - Returns: The equivalent `CGImagePropertyOrientation` to use for the device's current orientation.
+    func deviceExifOrientation() -> CGImagePropertyOrientation {
+        switch UIDevice.current.orientation {
+        case .landscapeRight: return .upMirrored
+        case .portraitUpsideDown: return .leftMirrored
+        case .landscapeLeft: return .downMirrored
+        case .portrait: return .rightMirrored
+        default:    // unknown or flat.
+            var screenBounds: CGRect?
+            DispatchQueue.main.sync {   // This needs to be done as `UIApplication` calls need to be done on the main thread.
+                screenBounds = UIApplication.firstKeyWindowForConnectedScenes?.windowScene?.screen.bounds
+            }
+            guard let screenBounds, screenBounds.width > screenBounds.height
+            else { return .rightMirrored }  // assume portrait
+            return .downMirrored    // assume landscapeLeft
         }
     }
 }

--- a/OSBarcodeLib/Scanner/OSBARCScannerViewControllerRepresentable.swift
+++ b/OSBarcodeLib/Scanner/OSBARCScannerViewControllerRepresentable.swift
@@ -4,18 +4,18 @@ import SwiftUI
 /// Structure responsible for bridging `OSBARCScannerViewController` into SwiftUI.
 struct OSBARCScannerViewControllerRepresentable: UIViewControllerRepresentable {
     /// The camera used to capture video for barcode scanning.
-    private var captureDevice: AVCaptureDevice?
+    private let captureDevice: AVCaptureDevice?
     
     /// The object containing the value to return.
     @Binding private var scanResult: String
     
     /// Indicates if scanning should be done only after a button click or automatically.
-    private var scanThroughButton: Bool
+    private let scanThroughButton: Bool
     /// Indicates if scanning is enabled (when there's a Scan Button).
     @Binding private var scanButtonEnabled: Bool
     
     /// Orientation the screen should adapt to.
-    private var orientationModel: OSBARCOrientationModel
+    private let orientationModel: OSBARCOrientationModel
     
     /// Constructor method.
     /// - Parameters:
@@ -39,6 +39,7 @@ struct OSBARCScannerViewControllerRepresentable: UIViewControllerRepresentable {
     func updateUIViewController(_ uiViewController: OSBARCScannerViewController, context: Context) {
         // Required but nothing to do here.
     }
+    
     func makeCoordinator() -> OSBARCScannerViewControllerCoordinator {
         Coordinator($scanResult, scanThroughButton, $scanButtonEnabled)
     }


### PR DESCRIPTION
## Description
Set `detectBarcodeRequest`'s `regionOfInterest` property so that scanning is only applied to the specific zone for it. The frame to apply is the same as the one used to construct the `OSBARCScannerView`.

The `regionOfInterest` property is updated based on a new `scanFrameChanged` frame that is set whenever `OSBARCScannerView`'s `scanFrame` property changes value (normally, on init and device rotation).

Change the way `OSBARCScannerView` is created: instead of incrementally building the screen with the black background, have this view set to the whole screen and apply a clip for the scanning zone.

Fix the issue of displaying the UI when `deviceOrientation` is set to `flatUp`/`flatDown`.

## Context
References: https://outsystemsrd.atlassian.net/browse/RMET-2771
References: https://outsystemsrd.atlassian.net/browse/RMET-2911

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests
Manual tests were done to verify that the feature works as expected.

## Screenshots
https://github.com/OutSystems/OSBarcodeLib-iOS/assets/97543217/1c115f89-24d3-4c50-8b0b-607735570070

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
