### PR TITLE
RMET-3585 ::: Fix Inverted Video Capture

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -1,11 +1,8 @@
 name: GitHub Actions
 
 on:
-  workflow_dispatch:
-  push:
-    branches: [ main, development ]
   pull_request:
-    branches: [ main, development ]
+    types: [opened, synchronize, reopened]
 
 jobs:    
   test:
@@ -14,23 +11,34 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+
     - name: Setup Java 17
       uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: '17'
+
+    - name: Link SwiftLint or install it
+      run: brew link --overwrite swiftlint || brew install swiftlint
+
+    - name: Set up XCode 
+      run: sudo xcode-select --switch /Applications/Xcode_15.0.app
+
     - name: Bundle Install
       run: bundle install
+
     - name: Unit tests
       run: bundle exec fastlane unit_tests
-      env:
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
     - name: Code Coverage
       run: bundle exec fastlane coverage
+
     - name: Lint
       run: bundle exec fastlane lint
+
     - name: Setup sonarqube
       uses: warchant/setup-sonar-scanner@v8
+
     - name: Send to Sonarcloud
       run: bundle exec fastlane sonarqube
       env: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+- Fix upside down video capture stream (https://outsystemsrd.atlassian.net/browse/RMET-3585).
+
+## 1.1.0
+
 ### Chores
 - Update `github_actions.yml` file steps versions (https://outsystemsrd.atlassian.net/browse/RMET-2568).
 - Set up the repo to release on CocoaPods (https://outsystemsrd.atlassian.net/browse/RMET-3301).
@@ -14,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add zooming out feature (https://outsystemsrd.atlassian.net/browse/RMET-2986).
 - Add zooming in feature (https://outsystemsrd.atlassian.net/browse/RMET-2986).
 
-## [1.0.0]
+## 1.0.0
 
 ### Features
 - Implement iPad user interface (https://outsystemsrd.atlassian.net/browse/RMET-2911).

--- a/OSBarcodeLib.xcodeproj/project.pbxproj
+++ b/OSBarcodeLib.xcodeproj/project.pbxproj
@@ -656,6 +656,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.outsystems.rd.barcode.OSBarcodeLib;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -693,6 +696,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.outsystems.rd.barcode.OSBarcodeLib;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/OSBarcodeLib/Scanner/Extensions/AVCaptureVideoOrientation+CustomInit.swift
+++ b/OSBarcodeLib/Scanner/Extensions/AVCaptureVideoOrientation+CustomInit.swift
@@ -4,14 +4,15 @@ import UIKit
 /// Extension that maps a `UIDeviceOrientation` into an `AVCaptureVideoOrientation`.
 extension AVCaptureVideoOrientation {
     /// Mapper construtor.
-    /// - Parameter deviceOrientation: Value to be converted from.
-    init?(deviceOrientation: UIDeviceOrientation) {
-        switch deviceOrientation {
+    /// - Parameter interfaceOrientation: Value to be converted from.
+    init?(interfaceOrientation: UIInterfaceOrientation) {
+        switch interfaceOrientation {
         case .portrait: self = .portrait
         case .portraitUpsideDown: self = .portraitUpsideDown
-        case .landscapeLeft: self = .landscapeRight
-        case .landscapeRight: self = .landscapeLeft
-        default: return nil
+        case .landscapeLeft: self = .landscapeLeft
+        case .landscapeRight: self = .landscapeRight
+        case .unknown: return nil
+        @unknown default: return nil
         }
     }
 }

--- a/OSBarcodeLibTests/OSBARCManagerFactoryTests.swift
+++ b/OSBarcodeLibTests/OSBARCManagerFactoryTests.swift
@@ -5,6 +5,6 @@ final class OSBARCManagerFactoryTests: XCTestCase {
     func testManagerCreationWithFactoryMethod() {
         let viewController = UIViewController()
         let manager = OSBARCManagerFactory.createManager(with: viewController)
-        XCTAssertTrue(manager as? OSBARCManager != nil)
+        XCTAssertTrue(manager is OSBARCManager)
     }
 }

--- a/OSBarcodeLibTests/OSBARCTestValues.swift
+++ b/OSBarcodeLibTests/OSBARCTestValues.swift
@@ -1,7 +1,3 @@
 struct OSBARCScannerStubValues {
     static let scannedCode = "Scanned Code"
 }
-
-struct OSBARCCommonValues {
-    static let failMessage = "Shouldn't get here"
-}


### PR DESCRIPTION
## Description
Instead of `UIDevice`'s `deviceOrientation`, use `UIWindowScene`'s `interfaceOrientation`. Not only do we avoid the `faceUp` and `faceDown` validations, but the rotations are similar to `AVCaptureVideoOrientation`'s, with no need to map `landscapeRight` to `landscapeLeft` and vice-versa.

The PR also address the following:
- Simplify unit test checks.
- Remove unused project targets.
- Fix pipeline issues.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-3585
Fixes https://github.com/OutSystems/OSBarcodeLib-iOS/issues/18.

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality not to work as expected)

## Tests
Manual testing was performed to validate the fix. 

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
