### PR TITLE
RMET- 3374:: add minimum confidence value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Adds check to scan result confidence value (https://outsystemsrd.atlassian.net/browse/RMET-3374).
+
 ## 1.1.1
 
 ### Fixes

--- a/OSBarcodeLib/Scanner/CameraManager/OSBARCCaptureOutputDecoder.swift
+++ b/OSBarcodeLib/Scanner/CameraManager/OSBARCCaptureOutputDecoder.swift
@@ -91,7 +91,7 @@ private extension OSBARCCaptureOutputDecoder {
     /// - Parameter request: Vision request handler that performs image analysis.
     func processClassification(for request: VNRequest) {
         DispatchQueue.main.async {
-            if let bestResult = request.results?.first as? VNBarcodeObservation, let payload = bestResult.payloadStringValue {
+            if let bestResult = request.results?.first as? VNBarcodeObservation, bestResult.confidence > 0.9, let payload = bestResult.payloadStringValue {
                 AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
                 self.scanResult = payload
             }


### PR DESCRIPTION
## Description
When returning the scanned barcode value, it was returning it independently of its confidence value. 
This PR checks the confidence value and only returns it if it's value is above `0.9`

## Context
For more context, check this [JIRA](https://outsystemsrd.atlassian.net/browse/RMET-3374) issue

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
Tested with the Code-39 barcode presented in the community forum post
![Screenshot 2024-08-23 at 11 15 41](https://github.com/user-attachments/assets/5fb9695c-5d28-4e07-83e8-1296f9a3629e)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
