### PR TITLE
fix: Ambiguity between UPC-A and EAN-13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Fix ambiguity between UPC-A and EAN-13 when hint is provided.
+
 ## 2.0.0
 
 **BREAKING CHANGE**: The signature of `scanBarcode` has been updated, both input and output.

--- a/OSBarcodeLib/Scanner/CameraManager/OSBARCCaptureOutputDecoder.swift
+++ b/OSBarcodeLib/Scanner/CameraManager/OSBARCCaptureOutputDecoder.swift
@@ -88,7 +88,7 @@ private extension OSBARCCaptureOutputDecoder {
         DispatchQueue.main.async {
             if let bestResult = request.results?.first as? VNBarcodeObservation, bestResult.confidence > 0.9, let payload = bestResult.payloadStringValue {
                 AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
-                let format = OSBARCScannerHint.fromVNBarcodeSymbology(bestResult.symbology)
+                let format = OSBARCScannerHint.fromVNBarcodeSymbology(bestResult.symbology, withHint: self.hint)
                 self.scanResult = OSBARCScanResult(text: payload, format: format)
             }
         }

--- a/OSBarcodeLib/Scanner/Extensions/OSBARCScannerHint+VNBarcodeSymbology.swift
+++ b/OSBarcodeLib/Scanner/Extensions/OSBARCScannerHint+VNBarcodeSymbology.swift
@@ -10,7 +10,16 @@ extension OSBARCScannerHint {
         }
     }
     
-    static func fromVNBarcodeSymbology(_ symbology: VNBarcodeSymbology) -> OSBARCScannerHint {
+    static func fromVNBarcodeSymbology(_ symbology: VNBarcodeSymbology, withHint hint: OSBARCScannerHint? = nil) -> OSBARCScannerHint {
+        if (symbology == .ean13) {
+            // UPC-A and EAN-13 have similar format, and Apple Vision does not distinguish between the two
+            // if a specific hint was provided, return that as the format
+            switch hint {
+                case .upcA: return .upcA
+                case .ean13: return .ean13
+                default: break
+            }
+        }
         return Self.hintMappings.first { (_, symbologies) in
             symbologies.contains(symbology)
         }?.key ?? .unknown


### PR DESCRIPTION
Support for hints, introduced in https://github.com/OutSystems/OSBarcodeLib-iOS/pull/31, contains some ambiguity in `UPC-A` and `EAN-13` formats, which are very similar (visually they look similar, and both have 13 digits).

There is no `.upca` symbiology in [Apple Vision](https://developer.apple.com/documentation/vision/vnbarcodesymbology), so there is no way to distinguish if a scanned barcode is of format `UPC-A` or `EAN-13`. What this PR does is check the provided hint, if a barcode of symbiology `.ean13` was scanned, if the hint used was `.ean13` or `.upca`, then that hint is returned as format.