### PR TITLE
fix(ios): bundle resources into Swift Package 

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -22,7 +22,7 @@ jobs:
       run: brew link --overwrite swiftlint || brew install swiftlint
 
     - name: Set up XCode 
-      run: sudo xcode-select --switch /Applications/Xcode_26.0.app
+      run: sudo xcode-select --switch /Applications/Xcode_26.2.app
 
     - name: Bundle Install
       run: bundle install

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -25,7 +25,7 @@ jobs:
         run: brew link --overwrite swiftlint || brew install swiftlint
 
       - name: Set up XCode 
-        run: sudo xcode-select --switch /Applications/Xcode_26.0.app
+        run: sudo xcode-select --switch /Applications/Xcode_26.2.app
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fix
+
+- Bundle missing resources into the Swift Package [RMET-4952](https://outsystemsrd.atlassian.net/browse/RMET-4952).
+
 ## 2.1.0
 
 ### Features

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,10 @@ let package = Package(
     targets: [
         .target(
             name: "OSBarcodeLib",
-            path: "Sources/OSBarcodeLib"
+            path: "Sources/OSBarcodeLib",
+            resources: [
+                .process("Scanner/OSBARCScannerView.xcassets")
+            ]
         ),
         .testTarget(
             name: "OSBarcodeLibTests",

--- a/Sources/OSBarcodeLib/Scanner/Interface Elements/OSBARCTorchButton.swift
+++ b/Sources/OSBarcodeLib/Scanner/Interface Elements/OSBARCTorchButton.swift
@@ -27,7 +27,7 @@ struct OSBARCTorchButton: View {
         
     var body: some View {
         Button(action: action) {
-            Image(iconName, bundle: .init(for: OSBARCScannerBehaviour.self))    // xcassets item.
+            Image(iconName, bundle: Bundle.imageBundle)
                 .frame(width: size, height: size)
                 .background(
                     Circle()
@@ -40,5 +40,18 @@ struct OSBARCTorchButton: View {
                     )
                 }
         }
+    }
+}
+
+// MARK: - Bundle Extension
+private extension Bundle {
+    /// Returns the appropriate bundle for loading image assets.
+    /// Uses Bundle.module for SwiftPM and falls back to the class bundle for CocoaPods.
+    static var imageBundle: Bundle? {
+        #if SWIFT_PACKAGE
+        return Bundle.module
+        #else
+        return Bundle(for: OSBARCScannerBehaviour.self)
+        #endif
     }
 }


### PR DESCRIPTION
## Description

```
⚠️ AI-assisted PR with claude code, reviewed and validated by me.
```

Current SPM support lacks bundling the library's resources: flash on / flash off icons. This was causing a UI bug in iOS apps with SPM where the icons to be missing when opening the barcode scan screen.

This PR adds missing resources to `Package.swift` and corrects the SwiftUI code to retrieve the resource bundle properly.

## Context

- https://github.com/ionic-team/capacitor-barcode-scanner/issues/109
- https://outsystemsrd.atlassian.net/browse/RMET-4952

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests

Pointed the capacitor [example spm app to this branch](https://github.com/ionic-team/capacitor-barcode-scanner/tree/RMET-4952), now the torch icons appear.

Also tested that CocoaPods still works by building the xcframework from this branch and replacing it the app.
