### PR TITLE
fix: use Xcode 16 instead of 26

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -22,7 +22,7 @@ jobs:
       run: brew link --overwrite swiftlint || brew install swiftlint
 
     - name: Set up XCode 
-      run: sudo xcode-select --switch /Applications/Xcode_26.2.app/Contents/Developer
+      run: sudo xcode-select --switch /Applications/Xcode_16.4.app/Contents/Developer
 
     - name: Bundle Install
       run: bundle install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  XCODE_VERSION: 26.2
+  XCODE_VERSION: 16.4
   NODE_VERSION: '24'
 
 permissions:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Updates workflows to build framework with Xcode 16 instead of 26.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
